### PR TITLE
Avoid calling setTimeout without context

### DIFF
--- a/addon/utils/raf.js
+++ b/addon/utils/raf.js
@@ -4,7 +4,7 @@ import nativeSetTimeout from './set-timeout';
 let addToFrame = globalScope.requestAnimationFrame;
 if (!addToFrame) {
   addToFrame = function(method) {
-    return nativeSetTimeout(() => {
+    return nativeSetTimeout.call(null, () => {
       method(new Date().getTime());
     }, 0);
   };


### PR DESCRIPTION
Currently, this module breaks `setTimeout` calls in browsers that don't have `requestAnimationFrame`.

For browsers without `requestAnimationFrame`, the replacement, which calls `setTimeout`, wasn't calling it with a function context, resulting in `Uncaught TypeError: Illegal invocation` in Chrome.
