### PR TITLE
Fix isFastboot check

### DIFF
--- a/addon/utils/is-fastboot.js
+++ b/addon/utils/is-fastboot.js
@@ -1,4 +1,4 @@
-/* global FastBoot */
+/* global process */
 export default function isFastboot() {
-  return typeof FastBoot !== 'undefined';
+  return (typeof process !== 'undefined' && process.env && process.env.EMBER_CLI_FASTBOOT);
 }


### PR DESCRIPTION
For some reason the fastboot check with typeof FastBoot !== 'undefined' didnt work for me and
other users see: issue #5 (https://github.com/runspired/ember-run-raf/issues/5), I tried to implement a fixed base on the following discussions: https://github.com/ember-fastboot/ember-cli-fastboot/issues/105 and https://github.com/plusacht/ember-bootstrap-datetimepicker/pull/75
