### PR TITLE
Prevent clearTimeout from throwing an illegal invocation TypeError

### DIFF
--- a/addon/utils/clear-timeout.js
+++ b/addon/utils/clear-timeout.js
@@ -1,3 +1,3 @@
 import globalScope from './global-scope';
-const nativeClearTimeout = globalScope.clearTimeout;
+const nativeClearTimeout = globalScope.clearTimeout.bind(globalScope);
 export default nativeClearTimeout;

--- a/tests/unit/utils/clear-timeout-test.js
+++ b/tests/unit/utils/clear-timeout-test.js
@@ -1,0 +1,21 @@
+import nativeClearTimeout from 'ember-run-raf/utils/clear-timeout';
+
+import { module, test } from 'qunit';
+
+module('Unit | Utility | clear-timeout');
+
+test('Module Exists', function(assert) {
+  assert.ok(nativeClearTimeout);
+});
+
+test("Calling the exported clearTimeout doesn't throw an illegal invocation TypeError", function(assert) {
+  assert.expect(1);
+
+  var catchBlockNotEntered = true;
+  try {
+    nativeClearTimeout();
+  } catch (err){
+    catchBlockNotEntered = false;
+  }
+  assert.ok(catchBlockNotEntered, "calling nativeClearTimeout didn't cause an error");
+});


### PR DESCRIPTION
ember-run-raf/utils/clear-timeout exports the clearTimeout function without binding it to the global scope. However, both ember-run-raf/utils/raf's clearFrame and ember-run-raf/utils/set-timeout-override's clearTimeout call nativeClearTimeout without a context, which causes a TypeError to be thrown.
