### PR TITLE
fixed app.import to ensure ember-run-raf works in Ember engines

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,11 @@ module.exports = {
   name: 'ember-run-raf',
 
   included: function(app) {
-    app.import(app.bowerDirectory + '/animation-frame/AnimationFrame.min.js');
+    if (typeof this.import === 'function' && !app.bowerDirectory) {
+      this.import('bower_components/animation-frame/AnimationFrame.min.js');
+    } else {
+      app.import(app.bowerDirectory + '/animation-frame/AnimationFrame.min.js');
+    }
   },
 
   isDevelopingAddon: function() {


### PR DESCRIPTION
This is a fix for the following issue:
https://github.com/runspired/ember-run-raf/issues/12
