### PR TITLE
fix: update ember-cli-babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "fps"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.5"
+    "ember-cli-babel": "^6.12.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Since v5 is deprecated now